### PR TITLE
abort parsing if pathOrder statement does not contain all outgoing paths

### DIFF
--- a/src/test/java/ac/at/tuwien/infosys/visp/topologyParser/SplitJoinTest.java
+++ b/src/test/java/ac/at/tuwien/infosys/visp/topologyParser/SplitJoinTest.java
@@ -1,12 +1,15 @@
 package ac.at.tuwien.infosys.visp.topologyParser;
 
-import ac.at.tuwien.infosys.visp.common.operators.*;
+import ac.at.tuwien.infosys.visp.common.operators.Operator;
+import ac.at.tuwien.infosys.visp.common.operators.Split;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.*;
+
+import static junit.framework.TestCase.fail;
 
 public class SplitJoinTest {
 
@@ -87,6 +90,17 @@ public class SplitJoinTest {
             }
         }
         Assert.assertTrue("Not able to reach source from sink", false);
+    }
+
+    @Test
+    public void test_splitPathOrderIncomplete() {
+        try {
+            TopologyParser tp = new TopologyParser();
+            TopologyParser.ParseResult pr = tp.parseTopologyFromClasspath("split_join_pathOrderIncomplete.conf");
+            fail("Parser should throw exception because pathOrder does not contain $step2b");
+        } catch(RuntimeException rt) {
+
+        }
     }
 
 

--- a/src/test/resources/split_join_pathOrderIncomplete.conf
+++ b/src/test/resources/split_join_pathOrderIncomplete.conf
@@ -1,0 +1,70 @@
+ $source = Source() {
+  concreteLocation = 192.168.0.1/openstackpool,
+  type             = source,
+  outputFormat     = "temperature data from sensor XYZ",
+  #meaningless for sources and should be ignored by parser:
+  expectedDuration = 15.2
+ }
+
+ $step1 = Operator($source) {
+  allowedLocations = 192.168.0.1/openstackpool,
+  concreteLocation = 192.168.0.1/openstackpool,
+  inputFormat      = step1,
+  type             = step1,
+  outputFormat     = step2,
+  size             = small,
+  stateful = false
+ }
+
+ $split = Split($step1) {
+   pathOrder = $step2a
+ }
+
+ $step2a = Operator($split) {
+  allowedLocations = 192.168.0.1/openstackpool,
+  inputFormat      = step1,
+  type             = "step2a",
+  outputFormat     = "step3",
+  size             = small,
+  stateful         = false,
+ }
+
+$step3 = Operator($step2a) {
+    allowedLocations = 192.168.0.1/openstackpool,
+    concreteLocation = 192.168.0.1/openstackpool,
+    inputFormat      = step2a,
+    type             = step3,
+    outputFormat     = step4,
+    size             = small,
+    stateful = false
+}
+
+$step2b = Operator($split) {
+    allowedLocations = 192.168.0.1/openstackpool,
+    concreteLocation = 192.168.0.1/openstackpool,
+    inputFormat      = step1,
+    type             = step2b,
+    outputFormat     = step4,
+    # pathOrder is ignored on non-split nodes
+    pathOrder = $step1,
+    size             = small,
+    stateful = false
+}
+
+$join = Join($step3, $step2b) {}
+
+$step4 = Operator($join) {
+    allowedLocations = 192.168.0.1/openstackpool,
+    concreteLocation = 192.168.0.1/openstackpool,
+    inputFormat      = step4,
+    type             = step4,
+    outputFormat     = log,
+    size             = small,
+    stateful = false
+}
+
+ $log = Sink($step4) {
+  concreteLocation = 192.168.0.1/openstackpool,
+  inputFormat      = "step4",
+  type             = "log",
+ }


### PR DESCRIPTION
pathOrder determines the priority in which alternative paths are used. The pathOrder must include _all_ fallback paths. If this is not the case, an exception is thrown directly after parsing.