### PR TITLE
Handle Split/Join Operators when Creating Topology File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[ ![Download](https://api.bintray.com/packages/chochreiner/visp/topologyParser/images/download.svg) ](https://bintray.com/chochreiner/visp/topologyParser/_latestVersion)
+[![Build Status](https://travis-ci.org/visp-streaming/topologyParser.svg?branch=master)](https://travis-ci.org/visp-streaming/topologyParser)
+
 # TopologyParser
 
 This antlr-based parser is used to read configuration files

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ac.at.tuwien.infosys.visp</groupId>
     <artifactId>topologyParser</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.6</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/ac/at/tuwien/infosys/visp/topologyParser/TopologyParser.java
+++ b/src/main/java/ac/at/tuwien/infosys/visp/topologyParser/TopologyParser.java
@@ -87,7 +87,7 @@ public class TopologyParser {
 
         File dotFile = File.createTempFile("graphviz", ".dot");
 
-
+        File fluxFile = File.createTempFile("topology", ".flux");
 
         // in this method, the generated parse tree is walked
         // here, the actual topology is created
@@ -99,6 +99,9 @@ public class TopologyParser {
         for (Operator o : topologyListener.getTopology().values()) {
             logger.debug(o.toString());
         }
+
+        topologyListener.writeFluxFile(fluxFile.getAbsolutePath());
+        logger.info("Wrote flux file to " + fluxFile);
 
         Map<String, Operator> topology = topologyListener.getTopology();
 

--- a/src/main/java/ac/at/tuwien/infosys/visp/topologyParser/antlr/listener/TopologyListener.java
+++ b/src/main/java/ac/at/tuwien/infosys/visp/topologyParser/antlr/listener/TopologyListener.java
@@ -109,12 +109,29 @@ public class TopologyListener extends VispBaseListener {
                 LOG.warn("Source of operator " + op.getName() + " is null...");
                 continue;
             }
-            linesToWriteToFlux.add("  - name: \"" + source.getName() + " --> " + op.getName() + "\"\n");
-            linesToWriteToFlux.add("    from: \"" + source.getName() + "\"\n");
-            linesToWriteToFlux.add("    to: \"" + op.getName() + "\"\n");
-            linesToWriteToFlux.add("    grouping:\n");
-            linesToWriteToFlux.add("      type: SHUFFLE\n"); // TODO
+            if(source instanceof Join) {
+                // skip Join and treat its sources as sources for current operator
+                for(Operator grandSource : source.getSources()) {
+                    helpPrintStreamFlux(grandSource, op, linesToWriteToFlux);
+                }
+            } else if(source instanceof Split) {
+                // skip Split and treat its sources as sources for current operator
+                for(Operator grandSource : source.getSources()) {
+                    helpPrintStreamFlux(grandSource, op, linesToWriteToFlux);
+                }
+            } else {
+                helpPrintStreamFlux(source, op, linesToWriteToFlux);
+            }
+
         }
+    }
+
+    private void helpPrintStreamFlux(Operator source, Operator op, List<String> linesToWriteToFlux) {
+        linesToWriteToFlux.add("  - name: \"" + source.getName() + " --> " + op.getName() + "\"\n");
+        linesToWriteToFlux.add("    from: \"" + source.getName() + "\"\n");
+        linesToWriteToFlux.add("    to: \"" + op.getName() + "\"\n");
+        linesToWriteToFlux.add("    grouping:\n");
+        linesToWriteToFlux.add("      type: SHUFFLE\n");
     }
 
     @Override

--- a/src/test/java/ac/at/tuwien/infosys/visp/topologyParser/TopologyWriteTest.java
+++ b/src/test/java/ac/at/tuwien/infosys/visp/topologyParser/TopologyWriteTest.java
@@ -1,0 +1,39 @@
+package ac.at.tuwien.infosys.visp.topologyParser;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class TopologyWriteTest {
+    TopologyParser topologyParser;
+
+    @Before
+    public void init() {
+        topologyParser = new TopologyParser();
+    }
+
+
+    @Test
+    public void test_identicalTopologies_noChanges() throws IOException {
+        TopologyParser.ParseResult pr = topologyParser.parseTopologyFromClasspath("split_join_sequence.conf");
+        assertTrue(pr.topology.containsKey("step2"));
+        String outPath = topologyParser.generateTopologyFile(pr.topology);
+
+        String content = new String(Files.readAllBytes(Paths.get(outPath)));
+
+        String[] split = content.split("Split");
+        String[] split2 = split[1].split("}");
+        assertTrue(split2[0].contains("pathOrder"));
+        assertFalse(split2[0].contains("concreteLocation"));
+    }
+
+
+}

--- a/src/test/resources/split_join_sequence.conf
+++ b/src/test/resources/split_join_sequence.conf
@@ -1,0 +1,58 @@
+$source = Source() {
+ concreteLocation = 128.130.172.220/openstack,
+ type             = source,
+ outputFormat     = "temperature data from sensor XYZ",
+ #meaningless for sources and should be ignored by parser:
+ expectedDuration = 15.2
+}
+
+$step1 = Operator($source) {
+ allowedLocations = 128.130.172.220/openstack,
+ concreteLocation = 128.130.172.220/openstack,
+ inputFormat      = step1,
+ type             = step1,
+ outputFormat     = step2,
+ size             = small,
+ stateful = false
+}
+
+$split = Split($step1) {
+  pathOrder = $step2 $step3
+}
+
+$step2 = Operator($split) {
+ allowedLocations = 128.130.172.220/openstack,
+ inputFormat      = step1,
+ type             = "step2",
+ outputFormat     = "step4",
+ size             = small,
+ stateful         = false,
+}
+
+$step3 = Operator($split) {
+   allowedLocations = 128.130.172.220/openstack,
+   concreteLocation = 128.130.172.220/openstack,
+   inputFormat      = step1,
+   type             = step3,
+   outputFormat     = step4,
+   size             = small,
+   stateful = false
+}
+
+$join = Join($step2, $step3) {}
+
+$step4 = Operator($join) {
+   allowedLocations = 128.130.172.220/openstack,
+   concreteLocation = 128.130.172.220/openstack,
+   inputFormat      = step4,
+   type             = step4,
+   outputFormat     = log,
+   size             = small,
+   stateful = false
+}
+
+$log = Sink($step4) {
+ concreteLocation = 128.130.172.220/openstack,
+ inputFormat      = "step4",
+ type             = "log",
+}

--- a/src/test/resources/topology_underscore_test.conf
+++ b/src/test/resources/topology_underscore_test.conf
@@ -15,7 +15,7 @@
   #expectedDuration = "350",
   #queueThreshold   = "100"
  }
-$step2 = Operator($step1, $source) {
+$step2 = Operator($step1_a, $source) {
   allowedLocations = 192.168.0.2/openstack,
   inputFormat      = "step1",
   type             = "step2",


### PR DESCRIPTION
The topology parser also creates a topology file from several runtime changes. Before this commit, Split and Join operators were not correctly handled during the creation of this exported topology file.